### PR TITLE
Optimization by pre-loading OSM data

### DIFF
--- a/tmou-mapa-backend/Cargo.lock
+++ b/tmou-mapa-backend/Cargo.lock
@@ -1164,6 +1164,7 @@ name = "tmou-mapa-backend"
 version = "0.1.0"
 dependencies = [
  "itertools",
+ "lazy_static",
  "rocket",
  "rocket_contrib",
  "roxmltree",

--- a/tmou-mapa-backend/Cargo.toml
+++ b/tmou-mapa-backend/Cargo.toml
@@ -14,4 +14,4 @@ serde_json = "1.0"
 serde_derive = "1.0"
 roxmltree = "0.13.0"
 itertools = "0.9.0"
-
+lazy_static = "1.4.0"

--- a/tmou-mapa-backend/src/game_controller.rs
+++ b/tmou-mapa-backend/src/game_controller.rs
@@ -10,6 +10,7 @@ use super::osm_logic::*;
 use super::errors::*;
 use super::map_contents::*;
 
+
 const FILLOVA_X_BROZIKOVA_NODE_ID: &str = "3750367566";
 const ZOOM: i32 = 17;
 const CENTER_X: i32 = 71586;
@@ -21,7 +22,7 @@ const CENTER_Y: i32 = 44885;
 
 pub fn get_pois(phrase: &RawStr) -> TmouResult<api::Pois>
 {
-    let osm = get_osm()?;
+    let osm = get_osm();
     let team = get_team_state(&phrase)?;
     let osm_ways= get_reachable_ways_for_node_id(&osm, team.position.to_string());
     let osm_nodes = get_nodes_in_ways(&osm, &osm_ways);
@@ -164,10 +165,33 @@ fn get_memory_db_control() -> TmouResult<impl DbControl>
     Ok(ctrl)
 }
 
-fn get_osm() -> TmouResult<osm::Osm>
+
+pub fn initialize()
+{
+    get_osm();
+}
+
+fn get_osm() ->  &'static osm::Osm
+{
+    &OSM_STATIC
+}
+
+fn create_osm() -> TmouResult<osm::Osm>
 {
     println!("reading OSM File");
     let fname = concat!(env!("CARGO_MANIFEST_DIR"), r"/pubfiles/tiles/osmdata.xml");
     println!("OSM Filename: {}", fname);
-    read_osm_from_file(fname)
+    let osm = read_osm_from_file(fname);
+    println!("Finished reading");
+    osm
 }
+
+lazy_static! 
+{
+    static ref OSM_STATIC:osm::Osm = 
+    {
+        let value = create_osm().unwrap();
+        value
+    };
+}
+

--- a/tmou-mapa-backend/src/main.rs
+++ b/tmou-mapa-backend/src/main.rs
@@ -1,6 +1,7 @@
 #![feature(proc_macro_hygiene, decl_macro)]
 
 #[macro_use] extern crate rocket;
+#[macro_use] extern crate lazy_static;
 
 use rocket::http::RawStr;
 use rocket::{Request, Data};
@@ -93,6 +94,7 @@ fn index() -> String
 
 fn main() 
 {
+    game_controller::initialize();
     rocket::ignite()
         .mount("/static", StaticFiles::from(concat!(env!("CARGO_MANIFEST_DIR"), "/static")))
         .mount("/", routes![index, info, go, discover, /*pois, grid, */ team_index])


### PR DESCRIPTION
Použitá knihovna lazy_static pro usnadnění práce, ale statická OSM data nejsou ve skutečnosti lazy - při startu serveru se explicitně inicializují, aby to později nezdržovalo. Pokud načítání selže, server panikaří. Poté už jednotlivé requesty chodí na předpřipravená data a odpovědi serveru jsou o dva řády rychlejší.