### PR TITLE
Rate limiter implementation and environment variable documentation

### DIFF
--- a/tmou-mapa-backend/.vscode/tasks.json
+++ b/tmou-mapa-backend/.vscode/tasks.json
@@ -55,7 +55,7 @@
         },
         {
             "type": "shell",
-            "command": "cargo test -- --skip admin_is_protected_by_password",
+            "command": "cargo test -- --skip admin_is_protected_by_password -- skip phrase_are_guarded_by_admin",
             "label": "Rust: cargo test without failing admin",
             "group": {
                 "kind": "build",

--- a/tmou-mapa-backend/README.md
+++ b/tmou-mapa-backend/README.md
@@ -14,6 +14,15 @@ Aplikace pro servírování mapových dlaždic, uzlů a správy týmů pro onlin
 2. `rustup override set nightly` 
 3. `ROCKET_DATABASES='{postgres={url="postgres://USER:PASSWORD@SERVER:PORT/DB_NAME"}}' cargo run` 
 
+## Proměnné prostředí
+
+Název | Formát | příklad | popis
+---|---|---|---
+TMOU_GAME_EXECUTION_MODE | On/Off/Auto | Auto | On - hra je zapnuta, Off, hra je vypnuta, Auto - hra se řídí proměnnými START a END (viz níže)
+TMOU_GAME_START | Čas podle [RFC3339](https://tools.ietf.org/html/rfc3339) | 2020-11-06T20:00:00+01:00 | Začátek hry; Čas, před kterým backend vrací chybu 
+TMOU_GAME_END | Čas podle [RFC3339](https://tools.ietf.org/html/rfc3339) | 2020-11-07T12:00:00+01:00 | Konec hry; Čas, po kterém už není možno objevovat uzly
+TMOU_GAME_RATE_LIMIT_CHECKING | On/Off | On | Zapínání kontroly minimálního času mezi dvěma požadavky týmu na přesun (viz níže)
+TMOU_GAME_RATE_LIMIT_IN_MS | integer | 1000 | Minimalní čas mezi dvěma požadavky týmu na přesun (proměnná neexistuje = 1000)
 
 ## Migrace
 

--- a/tmou-mapa-backend/src/rate_limiter.rs
+++ b/tmou-mapa-backend/src/rate_limiter.rs
@@ -1,0 +1,43 @@
+use std::result::Result;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry::{Occupied};
+use chrono::Utc;
+use chrono::DateTime;
+use std::sync::Mutex;
+
+pub struct RateLimiter  {
+    pub last_actions: Mutex<HashMap<i32, DateTime<Utc>>>
+} 
+
+impl RateLimiter {
+    pub fn new() -> RateLimiter {
+        RateLimiter { last_actions: Mutex::new(HashMap::new())}
+    }
+}
+
+fn enough_time_passed(from: &DateTime<Utc>, to: &DateTime<Utc>) -> bool
+{
+    let limit = std::env::var("TMOU_GAME_RATE_LIMIT_IN_MS")
+      .unwrap_or("1000".to_string())
+      .parse::<i64>()
+      .unwrap_or_else(|_| panic!("Parsing TMOU_GAME_RATE_LIMIT_IN_MS failed!"));
+    *to > *from + chrono::Duration::milliseconds(limit)
+}
+
+// when rate limit checking is ON:
+//   if not enough time passed from last action, returns Err(())
+//   otherwise, stores new timestamp and returns Ok(())
+// when rate limit checking is OFF: returns Ok(())
+pub fn check_rate_limit(limiter: & RateLimiter, team_id: &i32) -> Result<(),()>
+{
+    if std::env::var("TMOU_GAME_RATE_LIMIT_CHECKING").unwrap_or("On".to_string()) == "Off" { return Ok(());}
+    let now = Utc::now();
+    let mut actions = limiter.last_actions.lock().expect("locked");
+    match actions.entry(*team_id) {
+        Occupied(e) if !enough_time_passed(e.get(), &now) => Err(()),
+        e => {
+                e.insert(now);
+                Ok(())
+        }
+    }
+}


### PR DESCRIPTION
Rate limiter per tým: 

* defaultní čas mezi dvěma přesuny 1 s
* defaultně zapnuto
* v případě překročení vrací TooManyRequests
* proměnné prostředí - viz README.md
