### PR TITLE
Conditions with ownership properly done

### DIFF
--- a/tmou-mapa-backend/game_data.xml
+++ b/tmou-mapa-backend/game_data.xml
@@ -138,7 +138,7 @@
         <item name="puzzles-3" type="puzzles" description="šifra 3"
               url="https://drive.google.com/file/d/18pmSx5GS092wiL9CYKtq49QOClReHoAW/view?usp=sharing" level="3">
             <node id="440885619"/> <!--Netopyrky pomnik-->
-            <condition><![CDATA[ has(items, "puzzles-2") ]]></condition>
+            <condition><![CDATA[ has("puzzles-2") ]]></condition>
         </item>
         <item name="puzzles-4" type="puzzles" description="šifra 4"
               url="https://drive.google.com/file/d/1sBWjHteOfGLxnbs2AchqM8x3CO2io1ya/view?usp=sharing" level="4">

--- a/tmou-mapa-backend/src/controllers/discovery.rs
+++ b/tmou-mapa-backend/src/controllers/discovery.rs
@@ -255,19 +255,11 @@ pub fn evaluate_condition(
     inventory: &Items,
     player_level: i16,
 ) -> TmouResult<bool> {
-    let items: Vec<String> = inventory
-        .iter()
-        .map(|i| i.name.clone())
-        .collect::<Vec<String>>();
+    let items: Vec<String> = inventory.iter().map(|i| i.name.clone()).collect();
     let context = context_map! {
         "level" => player_level as i64,
         "has" => Function::new(Box::new(move |argument| {
-            if let Ok(item) = argument.as_string()
-            {
-                Ok(Value::Boolean(items.contains(&item)))
-            } else {
-                Err(EvalexprError::expected_string(argument.clone()))
-            }
+            argument.as_string().and_then(|item| Ok(Value::Boolean(items.contains(&item))))
         }))
     }
     .unwrap();

--- a/tmou-mapa-backend/src/import_game_data.rs
+++ b/tmou-mapa-backend/src/import_game_data.rs
@@ -77,7 +77,6 @@ fn parse_item<'a>(node: roxmltree::Node<'a, 'a>) -> TmouResult<(db::Item, Vec<i6
         .next()
         .and_then(|e| Some(e.text()))
         .and_then(|s| Some(s.unwrap().to_string()));
-        
 
     Ok((
         db::Item {

--- a/tmou-mapa-backend/src/tests/discovery_tests.rs
+++ b/tmou-mapa-backend/src/tests/discovery_tests.rs
@@ -594,7 +594,7 @@ fn evaluate_condition_returns_level_between_false() -> TmouResult<()> {
 #[test]
 fn evaluate_condition_returns_has_single_true() -> TmouResult<()> {
     let inventory = vec![item("puzzles", 0, "logika")];
-    let res = dis::evaluate_condition("has(items,\"logika\")", &inventory, 0)?;
+    let res = dis::evaluate_condition("has(\"logika\")", &inventory, 0)?;
     assert!(res);
     Ok(())
 }
@@ -602,7 +602,7 @@ fn evaluate_condition_returns_has_single_true() -> TmouResult<()> {
 #[test]
 fn evaluate_condition_returns_has_single_false() -> TmouResult<()> {
     let inventory = vec![item("puzzles", 0, "fyzika")];
-    let res = dis::evaluate_condition("has(items,\"logika\")", &inventory, 0)?;
+    let res = dis::evaluate_condition("has(\"logika\")", &inventory, 0)?;
     assert!(!res);
     Ok(())
 }
@@ -610,11 +610,7 @@ fn evaluate_condition_returns_has_single_false() -> TmouResult<()> {
 #[test]
 fn evaluate_condition_returns_has_oneof_true() -> TmouResult<()> {
     let inventory = vec![item("puzzles", 0, "fyzika")];
-    let res = dis::evaluate_condition(
-        "has(items,\"logika\") || has(items,\"fyzika\")",
-        &inventory,
-        0,
-    )?;
+    let res = dis::evaluate_condition("has(\"logika\") || has(\"fyzika\")", &inventory, 0)?;
     assert!(res);
     Ok(())
 }
@@ -622,11 +618,7 @@ fn evaluate_condition_returns_has_oneof_true() -> TmouResult<()> {
 #[test]
 fn evaluate_condition_returns_has_oneof_false() -> TmouResult<()> {
     let inventory = vec![item("puzzles", 0, "matematika")];
-    let res = dis::evaluate_condition(
-        "has(items,\"logika\") || has(items,\"fyzika\")",
-        &inventory,
-        0,
-    )?;
+    let res = dis::evaluate_condition("has(\"logika\") || has(\"fyzika\")", &inventory, 0)?;
     assert!(!res);
     Ok(())
 }
@@ -638,11 +630,7 @@ fn evaluate_condition_returns_has_both_true() -> TmouResult<()> {
         item("puzzles", 0, "matematika"),
         item("puzzles", 0, "logika"),
     ];
-    let res = dis::evaluate_condition(
-        "has(items,\"logika\") && has(items,\"fyzika\")",
-        &inventory,
-        0,
-    )?;
+    let res = dis::evaluate_condition("has(\"logika\") && has(\"fyzika\")", &inventory, 0)?;
     assert!(res);
     Ok(())
 }
@@ -653,11 +641,7 @@ fn evaluate_condition_returns_has_both_false() -> TmouResult<()> {
         item("puzzles", 0, "fyzika"),
         item("puzzles", 0, "matematika"),
     ];
-    let res = dis::evaluate_condition(
-        "has(items,\"logika\") && has(items,\"fyzika\")",
-        &inventory,
-        0,
-    )?;
+    let res = dis::evaluate_condition("has(\"logika\") && has(\"fyzika\")", &inventory, 0)?;
     assert!(!res);
     Ok(())
 }
@@ -670,7 +654,7 @@ fn evaluate_condition_returns_complex_true() -> TmouResult<()> {
         item("puzzles", 0, "logika"),
     ];
     let res = dis::evaluate_condition(
-        "has(items,\"logika\") && has(items,\"fyzika\") && level > 10",
+        "has(\"logika\") && has(\"fyzika\") && level > 10",
         &inventory,
         11,
     )?;
@@ -686,7 +670,7 @@ fn evaluate_condition_returns_complex_false() -> TmouResult<()> {
         item("puzzles", 0, "logika"),
     ];
     let res = dis::evaluate_condition(
-        "has(items,\"logika\") && has(items,\"fyzika\") && level > 10",
+        "has(\"logika\") && has(\"fyzika\") && level > 10",
         &inventory,
         10,
     )?;


### PR DESCRIPTION
- spravený ownership v `evaluate_condition`
- syntaxe zjednodušena z `has(items,<item>)` na `has(<item>)`